### PR TITLE
Chore // Uses buffering to get around final JSON chunk being arbitrarily split

### DIFF
--- a/lib/revelry_ai/stream.ex
+++ b/lib/revelry_ai/stream.ex
@@ -1,5 +1,15 @@
 defmodule RevelryAI.Stream do
-  @moduledoc false
+  @moduledoc """
+  Creates a readable stream of information that another process can consume.
+  """
+
+  @doc """
+  This is used for endpoints that support returning text as it is generated,
+  rather than waiting for the entire generation output to be ready.
+
+  Note: We use a buffer to store the response until we have a complete chunk. While RevelryAI usually returns the entire response at once, this is not guaranteed if
+  streaming across a network boundary.
+  """
   def new(start_fun) do
     Stream.resource(
       fn ->
@@ -55,7 +65,6 @@ defmodule RevelryAI.Stream do
     )
   end
 
-  # Modify this function if your ServerSentEvents.parse/1 returns differently
   defp parse_events(%{data: content}), do: [decode_json_content(content)]
   defp parse_events([%{data: content}]), do: [decode_json_content(content)]
   defp parse_events(_), do: []

--- a/lib/revelry_ai/stream.ex
+++ b/lib/revelry_ai/stream.ex
@@ -1,110 +1,70 @@
 defmodule RevelryAI.Stream do
   @moduledoc false
-
-  @doc """
-  Creates a readable stream of information that another process can consume.
-
-  This is used for endpoints that support returning text as it is generated,
-  rather than waiting for the entire generation output to be ready.
-  """
   def new(start_fun) do
     Stream.resource(
-      start_fun,
+      fn ->
+        case start_fun.() do
+          {:ok, %HTTPoison.AsyncResponse{id: id} = res} ->
+            {res, id, ""}
+
+          {:error, %HTTPoison.Error{} = error} ->
+            {:error, error}
+
+          %HTTPoison.AsyncResponse{id: id} = res ->
+            {res, id, ""}
+        end
+      end,
       fn
         {:error, %HTTPoison.Error{} = error} ->
-          {
-            [
-              %{
-                "status" => :error,
-                "reason" => error.reason
-              }
-            ],
-            error
-          }
+          {[%{"status" => :error, "reason" => error.reason}], {:halt, error}}
 
-        %HTTPoison.Error{} = error ->
-          {:halt, error}
+        {:halt, _} = halt ->
+          halt
 
-        res ->
-          {res, id} =
-            case res do
-              {:ok, %HTTPoison.AsyncResponse{id: id} = res} ->
-                {res, id}
-
-              %HTTPoison.AsyncResponse{id: id} = res ->
-                {res, id}
-            end
-
+        {res, id, buffer} ->
           receive do
             %HTTPoison.AsyncStatus{id: ^id, code: code} ->
               HTTPoison.stream_next(res)
 
-              case code do
-                200 ->
-                  {[], res}
-
-                _ ->
-                  {
-                    [
-                      %{
-                        "status" => :error,
-                        "code" => code,
-                        "choices" => []
-                      }
-                    ],
-                    res
-                  }
+              if code == 200 do
+                {[], {res, id, buffer}}
+              else
+                {[%{"status" => :error, "code" => code, "choices" => []}], {:halt, res}}
               end
 
-            %HTTPoison.AsyncHeaders{id: ^id, headers: _headers} ->
+            %HTTPoison.AsyncHeaders{id: ^id} ->
               HTTPoison.stream_next(res)
-              {[], res}
+              {[], {res, id, buffer}}
 
             %HTTPoison.AsyncChunk{chunk: chunk} ->
-              {events, _} = ServerSentEvents.parse(chunk)
+              combined_chunk = buffer <> chunk
 
-              data =
-                Enum.flat_map(events, &parse_events/1)
+              {events, rest_buffer} = ServerSentEvents.parse(combined_chunk)
+              data = Enum.flat_map(events, &parse_events/1)
 
               HTTPoison.stream_next(res)
-              {data, res}
+              {data, {res, id, rest_buffer}}
 
             %HTTPoison.AsyncEnd{} ->
               {:halt, res}
           end
       end,
-      fn %{id: id} ->
-        :hackney.stop_async(id)
+      fn
+        %{id: id} -> :hackney.stop_async(id)
       end
     )
   end
 
-  defp parse_events(%{data: content}) do
-    decoded = decode_json_content(content)
-    [decoded]
-  end
-
-  defp parse_events([%{data: content}]) do
-    decoded = decode_json_content(content)
-    [decoded]
-  end
-
-  defp parse_events(_) do
-    []
-  end
+  # Modify this function if your ServerSentEvents.parse/1 returns differently
+  defp parse_events(%{data: content}), do: [decode_json_content(content)]
+  defp parse_events([%{data: content}]), do: [decode_json_content(content)]
+  defp parse_events(_), do: []
 
   defp decode_json_content(data) do
     case Jason.decode(data) do
-      {:ok, %{"content" => content}} ->
-        content
-
-      {:ok, map} when is_map(map) ->
-        # For response_body events or other structured data
-        map
-
-      {:error, _error} ->
-        # Not JSON or doesn't have content field, return as is
-        data
+      {:ok, %{"content" => content}} -> content
+      {:ok, map} when is_map(map) -> map
+      {:error, _} -> data
     end
   end
 end


### PR DESCRIPTION
### Overview

It seems like the streaming wasn't working when a client was connection to a server, no matter how hard I tried. This was never working when we crossed a network boundary (ie, testing on staging vs production) and always working despite massive chunks when testing a server/client locally.

I hit upon the idea that this is caused by **chunk fragmentation due to how network boundaries handle HTTP streaming.** So even though we encode and send the final response as one single chunk, it sometimes non-deterministically gets split depending on how the proxy (or something else in front of the server) handles it.

The way I fixed this was instead of fixing that (which I couldn't figure out on Fly) but fixing it here by buffering the chunks so we get the complete response 👍 

I've tested this out using PJ's problematic prompt that shed light on this in the first place, and it seems to have done the trick.

```
    artifact_slug = "message_optimization"
    prompt_template_id = 11
    project_id = 3
```