### PR TITLE
build!: bump minimum Elixir version to 1.16

### DIFF
--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -14,8 +14,8 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp: "26"
-            elixir: "1.16"
+          - otp: "28"
+            elixir: "1.19"
     steps:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,8 +13,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - otp: "24"
-            elixir: "1.12"
           - otp: "26"
             elixir: "1.16"
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,8 @@ jobs:
         include:
           - otp: "26"
             elixir: "1.16"
+          - otp: "28"
+            elixir: "1.19"
     steps:
       - name: Set up Elixir
         uses: erlef/setup-beam@v1
@@ -55,7 +57,7 @@ jobs:
         run: mix compile --warnings-as-errors
 
       - name: Check formatting
-        if: matrix.elixir == '1.16' && matrix.otp == '26'
+        if: matrix.elixir == '1.19' && matrix.otp == '28'
         run: mix format --check-formatted
 
       - name: Cache PLT files for Dialyzer
@@ -69,7 +71,7 @@ jobs:
             plt-cache-
 
       - name: Check function specs with Dialyzer
-        if: matrix.elixir == '1.16' && matrix.otp == '26'
+        if: matrix.elixir == '1.19' && matrix.otp == '28'
         run: mix dialyzer
 
       - name: Run tests

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ erl_crash.dump
 /config/*.secret.exs
 .elixir_ls/
 test_script.exs
+.idea/
+*.iml

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-elixir 1.16.2-otp-26
-erlang 26.2
+elixir 1.19.3-otp-28
+erlang 28.2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ to get started. Copy `config/config.example-secret.exs` to
 
 ## Development Setup
 
-1. Make sure you have Elixir 1.12+ installed
+1. Make sure you have Elixir 1.16+ installed
 1. Clone the repo
 1. Run `mix deps.get`
 1. Run `mix test`

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule RevelryAI.MixProject do
       description: "An SDK for interacting with the RevelryAI API",
       license: "MIT",
       version: "0.2.0",
-      elixir: "~> 1.12",
+      elixir: "~> 1.16",
       deps: deps(),
       compilers: [:yecc, :leex] ++ Mix.compilers(),
       aliases: aliases(),


### PR DESCRIPTION
## Breaking Change
⚠️ Bumps minimum required Elixir version to 1.16 to support updating mimic to 2.2.0.

## Change
- Bump `.tool_versions` languages to use latest versions
  - Elixir bumped to `1.19.3-otp-28`
  - Erlang bumped to `28.2`
- Update CI flows to use latest language / otp versions



