### PR TITLE
chore: pin GH action references to Git SHAs

### DIFF
--- a/.github/workflows/publish-hex.yml
+++ b/.github/workflows/publish-hex.yml
@@ -2,7 +2,7 @@ name: Publish to Hex
 
 on:
   release:
-    types: [published]
+    types: [ published ]
 
 jobs:
   publish:
@@ -18,13 +18,13 @@ jobs:
             elixir: "1.19"
     steps:
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       # We want to use the newest deps here, since library users will not be
       # locked to our mix.lock versions

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,17 @@ jobs:
             elixir: "1.19"
     steps:
       - name: Set up Elixir
-        uses: erlef/setup-beam@v1
+        uses: erlef/setup-beam@fc68ffb90438ef2936bbb3251622353b3dcb2f93 # v1.24.0
         with:
           otp-version: ${{matrix.otp}}
           elixir-version: ${{matrix.elixir}}
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Cache deps
         id: cache-deps
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache_name: cache-elixir-deps
         with:
@@ -40,12 +40,13 @@ jobs:
 
       - name: Cache compiled build
         id: cache-build
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           cache-name: cache-compiled-build
         with:
           path: _build
-          key: ${{ runner.os }}-mix-${{ env.cache-name }}-elixir-${{ matrix.elixir }}-${{ hashFiles('**/mix.lock') }}
+          key: ${{ runner.os }}-mix-${{ env.cache-name }}-elixir-${{ matrix.elixir }}-${{
+            hashFiles('**/mix.lock') }}
           restore-keys: |
             ${{ runner.os }}-mix-${{ env.cache-name }}-elixir-${{ matrix.elixir }}-
             ${{ runner.os }}-mix-${{ matrix.elixir }}-
@@ -61,7 +62,7 @@ jobs:
         run: mix format --check-formatted
 
       - name: Cache PLT files for Dialyzer
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             _build/test/*.plt


### PR DESCRIPTION
connects to revelrylabs/revelry_ai#2988